### PR TITLE
Add warnings to most problematic GitHub MCP functions

### DIFF
--- a/github-mcp-server-config.json
+++ b/github-mcp-server-config.json
@@ -1,0 +1,8 @@
+{
+  "TOOL_PUSH_FILES_DESCRIPTION": "Push multiple files to a GitHub repository in a single commit. Generally more appropriate for initial setup than regular development, where local git workflow is typically preferred.",
+  "TOOL_CREATE_OR_UPDATE_FILE_DESCRIPTION": "Create or update a single file in a GitHub repository. If updating, you must provide the SHA of the file you want to update. Consider local file operations first when working with existing repositories.",
+  "TOOL_CREATE_BRANCH_DESCRIPTION": "Create a new branch in a GitHub repository. For active development workflows, consider local branch creation followed by pushing to remote.",
+  "TOOL_GET_FILE_CONTENTS_DESCRIPTION": "Get the contents of a file or directory from a GitHub repository. Best for files not available locally or when specifically needing the remote version.",
+  "TOOL_LIST_COMMITS_DESCRIPTION": "Get list of commits of a branch in a GitHub repository. For local repositories, consider using git log commands for better performance.",
+  "TOOL_GET_COMMITS_DESCRIPTION": "Get details for a commit from a GitHub repository. For commits in local repositories, local git commands may provide faster results."
+}

--- a/github-mcp-server-config.json
+++ b/github-mcp-server-config.json
@@ -1,8 +1,0 @@
-{
-  "TOOL_PUSH_FILES_DESCRIPTION": "Push multiple files to a GitHub repository in a single commit. Generally more appropriate for initial setup than regular development, where local git workflow is typically preferred.",
-  "TOOL_CREATE_OR_UPDATE_FILE_DESCRIPTION": "Create or update a single file in a GitHub repository. If updating, you must provide the SHA of the file you want to update. Consider local file operations first when working with existing repositories.",
-  "TOOL_CREATE_BRANCH_DESCRIPTION": "Create a new branch in a GitHub repository. For active development workflows, consider local branch creation followed by pushing to remote.",
-  "TOOL_GET_FILE_CONTENTS_DESCRIPTION": "Get the contents of a file or directory from a GitHub repository. Best for files not available locally or when specifically needing the remote version.",
-  "TOOL_LIST_COMMITS_DESCRIPTION": "Get list of commits of a branch in a GitHub repository. For local repositories, consider using git log commands for better performance.",
-  "TOOL_GET_COMMITS_DESCRIPTION": "Get details for a commit from a GitHub repository. For commits in local repositories, local git commands may provide faster results."
-}

--- a/pkg/github/repositories.go
+++ b/pkg/github/repositories.go
@@ -228,7 +228,7 @@ func ListBranches(getClient GetClientFn, t translations.TranslationHelperFunc) (
 // CreateOrUpdateFile creates a tool to create or update a file in a GitHub repository.
 func CreateOrUpdateFile(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("create_or_update_file",
-			mcp.WithDescription(t("TOOL_CREATE_OR_UPDATE_FILE_DESCRIPTION", "Create or update a single file in a GitHub repository. If updating, you must provide the SHA of the file you want to update.")),
+			mcp.WithDescription(t("TOOL_CREATE_OR_UPDATE_FILE_DESCRIPTION", "Create or update a single file in a GitHub repository. If updating, you must provide the SHA of the file you want to update. WARNING: For files in active development, strongly prefer local file operations followed by standard git workflow rather than direct API calls.")),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
 				Title:        t("TOOL_CREATE_OR_UPDATE_FILE_USER_TITLE", "Create or update file"),
 				ReadOnlyHint: toBoolPtr(false),
@@ -411,7 +411,7 @@ func CreateRepository(getClient GetClientFn, t translations.TranslationHelperFun
 // GetFileContents creates a tool to get the contents of a file or directory from a GitHub repository.
 func GetFileContents(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_file_contents",
-			mcp.WithDescription(t("TOOL_GET_FILE_CONTENTS_DESCRIPTION", "Get the contents of a file or directory from a GitHub repository")),
+			mcp.WithDescription(t("TOOL_GET_FILE_CONTENTS_DESCRIPTION", "Get the contents of a file or directory from a GitHub repository. Useful for searching across repositories, but for files in active development, prefer local file operations to avoid unnecessary API calls.")),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
 				Title:        t("TOOL_GET_FILE_CONTENTS_USER_TITLE", "Get file or directory contents"),
 				ReadOnlyHint: toBoolPtr(true),
@@ -719,7 +719,7 @@ func DeleteFile(getClient GetClientFn, t translations.TranslationHelperFunc) (to
 // CreateBranch creates a tool to create a new branch.
 func CreateBranch(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("create_branch",
-			mcp.WithDescription(t("TOOL_CREATE_BRANCH_DESCRIPTION", "Create a new branch in a GitHub repository")),
+			mcp.WithDescription(t("TOOL_CREATE_BRANCH_DESCRIPTION", "Create a new branch in a GitHub repository. WARNING: For active development, strongly prefer local git branch creation (git checkout -b) followed by pushing to remote. This remote operation should only be used when local git operations are not possible.")),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
 				Title:        t("TOOL_CREATE_BRANCH_USER_TITLE", "Create branch"),
 				ReadOnlyHint: toBoolPtr(false),
@@ -808,7 +808,7 @@ func CreateBranch(getClient GetClientFn, t translations.TranslationHelperFunc) (
 // PushFiles creates a tool to push multiple files in a single commit to a GitHub repository.
 func PushFiles(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("push_files",
-			mcp.WithDescription(t("TOOL_PUSH_FILES_DESCRIPTION", "Push multiple files to a GitHub repository in a single commit")),
+			mcp.WithDescription(t("TOOL_PUSH_FILES_DESCRIPTION", "Push multiple files to a GitHub repository in a single commit. WARNING: This bypasses standard git workflow and should only be used when local git operations (add, commit, push) are not possible. For normal development, prefer local git commands.")),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
 				Title:        t("TOOL_PUSH_FILES_USER_TITLE", "Push files to repository"),
 				ReadOnlyHint: toBoolPtr(false),


### PR DESCRIPTION
This PR adds explicit warnings to the descriptions of the most problematic GitHub MCP functions that frequently disrupt developer workflows by prioritizing remote API calls over local operations.

## Changes

The following function descriptions have been updated with clear warnings:

1. **github___push_files**
   - **Original**: "Push multiple files to a GitHub repository in a single commit"
   - **Modified**: "Push multiple files to a GitHub repository in a single commit. WARNING: This bypasses standard git workflow and should only be used when local git operations (add, commit, push) are not possible. For normal development, prefer local git commands."

2. **github___create_branch**
   - **Original**: "Create a new branch in a GitHub repository"
   - **Modified**: "Create a new branch in a GitHub repository. WARNING: For active development, strongly prefer local git branch creation (git checkout -b) followed by pushing to remote. This remote operation should only be used when local git operations are not possible."

3. **github___get_file_contents**
   - **Original**: "Get the contents of a file or directory from a GitHub repository"
   - **Modified**: "Get the contents of a file or directory from a GitHub repository. Useful for searching across repositories, but for files in active development, prefer local file operations to avoid unnecessary API calls."

4. **github___create_or_update_file**
   - **Original**: "Create or update a single file in a GitHub repository. If updating, you must provide the SHA of the file you want to update."
   - **Modified**: "Create or update a single file in a GitHub repository. If updating, you must provide the SHA of the file you want to update. WARNING: For files in active development, strongly prefer local file operations followed by standard git workflow rather than direct API calls."

## Rationale

These changes address the key issues identified in the customization plan:
- Remote API calls instead of local file operations
- Bypassing of standard git workflows
- Excessive token usage for large file operations
- Poor diff visibility for changes

The warnings are direct and explicit to discourage AI assistants from using these functions when local operations would be more appropriate, while still acknowledging their legitimate use cases.

## Implementation

The changes are made directly to the function descriptions in the Go source code, which should have a stronger effect than using the config file approach.